### PR TITLE
Remove trailing slash that breaks a hyperlink

### DIFF
--- a/slides/07-HOD-platform-and-technologies/1060-Mission-1-docker.md
+++ b/slides/07-HOD-platform-and-technologies/1060-Mission-1-docker.md
@@ -1,7 +1,7 @@
 ## Mission 1! Getting started with Docker
 
 1. Complete the docker getting started tutorial​
-https://docs.docker.com/engine/getstarted/​
+https://docs.docker.com/engine/getstarted
 
 1. Dockerise a simple NodeJS application (you can use one of your own applications if you like!)​
 https://github.com/UKHomeOffice/node-hello-world ​


### PR DESCRIPTION
The docker tutorial doesn't have a trailing slash in it, so clicking the link that does have a trailing slash results in a 404.

This commit removes that slash.